### PR TITLE
Update example to use GitHub proxy

### DIFF
--- a/Pod/Classes/LSSpan.h
+++ b/Pod/Classes/LSSpan.h
@@ -89,6 +89,16 @@
                       startTime:(NSDate*)startTime;
 
 /**
+ * The LightStep span's trace GUID
+ */
+- (NSString*)traceGUID;
+
+/**
+ * The LightStep span instance's GUID
+ */
+- (NSString*)guid;
+
+/**
  * Add a set of tags from the given dictionary. Existing key-value pairs will
  * be overwritten by any new tags.
  */

--- a/Pod/Classes/LSSpan.m
+++ b/Pod/Classes/LSSpan.m
@@ -134,24 +134,34 @@
     RLSpanRecord* record;
     @synchronized(self) {
         NSMutableArray* tagArray;
-        if ([m_tags count] > 0) {
-            tagArray = [[NSMutableArray alloc] initWithCapacity:[m_tags count]];
+        if (m_tags.count > 0) {
+            tagArray = [[NSMutableArray alloc] initWithCapacity:m_tags.count];
             for (NSString* key in m_tags ) {
                 RLKeyValue* pair = [[RLKeyValue alloc] initWithKey:key Value:m_tags[key]];
                 [tagArray addObject:pair];
             }
         }
-        record =[[RLSpanRecord alloc] initWithSpan_guid:m_guid
-                                           runtime_guid:m_tracer.runtimeGuid
-                                              span_name:m_operationName
-                                               join_ids:nil
-                                          oldest_micros:[m_startTime toMicros]
-                                        youngest_micros:[finishTime toMicros]
-                                             attributes:tagArray
-                                             error_flag:m_errorFlag
-                                            log_records:nil];
+
+        record = [[RLSpanRecord alloc] initWithSpan_guid:m_guid
+                                            runtime_guid:m_tracer.runtimeGuid
+                                               span_name:m_operationName
+                                                join_ids:nil
+                                           oldest_micros:[m_startTime toMicros]
+                                         youngest_micros:[finishTime toMicros]
+                                              attributes:tagArray
+                                              error_flag:m_errorFlag
+                                             log_records:nil];
     }
     [m_tracer _appendSpanRecord:record];
+}
+
+- (NSString*)traceGUID {
+    return [m_tags objectForKey:@"join:trace_guid"];
+}
+
+
+- (NSString*)guid {
+    return m_guid;
 }
 
 - (void)_addTags:(NSDictionary*)tags {

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -138,13 +138,13 @@ static float kFirstRefreshDelay = 0;
 
     NSString* traceGUID;
     if (parentSpan != nil) {
-        traceGUID = [parentSpan _getTag:@"join:trace_id"];
+        traceGUID = [parentSpan _getTag:@"join:trace_guid"];
     }
     if (traceGUID == nil) {
         traceGUID = [LSUtil generateGUID];
     }
     NSMutableDictionary* newTags = [NSMutableDictionary dictionaryWithDictionary:tags];
-    [newTags setObject:traceGUID forKey:@"join:trace_id"];
+    [newTags setObject:traceGUID forKey:@"join:trace_guid"];
 
     LSSpan* span = [[LSSpan alloc] initWithTracer:self
                                     operationName:operationName

--- a/examples/LightStepTestUI/LightStepTestUI/Info.plist
+++ b/examples/LightStepTestUI/LightStepTestUI/Info.plist
@@ -36,5 +36,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Remap GitHub URLs to LightStep proxy server
- Add LightStep-specific APIs to span to get the trace and span GUIDs
- Use of `join:trace_guid` instead of `join:trace_id` to be consistent with other libs
- Allow HTTP calls to be made from the example app
- Add headers to connect spans within the proxy
