### PR TITLE
Generate trace on missing username

### DIFF
--- a/Pod/Classes/LSSpan.h
+++ b/Pod/Classes/LSSpan.h
@@ -99,6 +99,11 @@
 - (NSString*)guid;
 
 /**
+ * LightStep specific method for logging an error (or exception).
+ */
+- (void)logError:(NSString*)message error:(NSObject*)errorOrException;
+
+/**
  * Add a set of tags from the given dictionary. Existing key-value pairs will
  * be overwritten by any new tags.
  */


### PR DESCRIPTION
## Summary
- Add LightStep-specific `logError:(NSString*) error::(NSObject*)` to do more detailed logging of error events
- Generate an error trace in the example project if the username does not exist
- Update to port 80
