### PR TITLE
Support TextMap inject/join and clean up id scheme

### DIFF
--- a/Pod/Classes/LSSpan.h
+++ b/Pod/Classes/LSSpan.h
@@ -88,6 +88,12 @@
                            tags:(NSDictionary*)tags
                       startTime:(NSDate*)startTime;
 
+/**
+ * Internal function.
+ *
+ * Creates a new span associated with the given tracer and the other optional
+ * parameters.
+ */
 - (instancetype) initWithTracer:(LSTracer*)tracer
                   operationName:(NSString*)operationName
                         traceId:(UInt64)traceId
@@ -114,12 +120,20 @@
  * The LightStep Span's probabilistically unique trace id.
  */
 @property (nonatomic) UInt64 traceId;
+
+/**
+ * The trace id as a hexadecimal string.
+ */
 @property (nonatomic, readonly) NSString* hexTraceId;
 
 /**
  * The LightStep Span's probabilistically unique (span) id.
  */
 @property (nonatomic) UInt64 spanId;
+
+/**
+ * The span id as a hexadecimal string.
+ */
 @property (nonatomic, readonly) NSString* hexSpanId;
 
 /**

--- a/Pod/Classes/LSSpan.h
+++ b/Pod/Classes/LSSpan.h
@@ -88,20 +88,39 @@
                            tags:(NSDictionary*)tags
                       startTime:(NSDate*)startTime;
 
+- (instancetype) initWithTracer:(LSTracer*)tracer
+                  operationName:(NSString*)operationName
+                        traceId:(UInt64)traceId
+                       parentId:(UInt64)parentId
+                           tags:(NSDictionary*)tags
+                      startTime:(NSDate*)startTime;
+
 /**
  * The LightStep span's trace GUID
  */
 - (NSString*)traceGUID;
 
 /**
- * The LightStep span instance's GUID
- */
-- (NSString*)guid;
-
-/**
  * LightStep specific method for logging an error (or exception).
  */
 - (void)logError:(NSString*)message error:(NSObject*)errorOrException;
+
+/**
+ * 
+ */
+@property (nonatomic, strong) NSDictionary* tags;
+
+/**
+ * The LightStep Span's probabilistically unique trace id.
+ */
+@property (nonatomic) UInt64 traceId;
+@property (nonatomic, readonly) NSString* hexTraceId;
+
+/**
+ * The LightStep Span's probabilistically unique (span) id.
+ */
+@property (nonatomic) UInt64 spanId;
+@property (nonatomic, readonly) NSString* hexSpanId;
 
 /**
  * Add a set of tags from the given dictionary. Existing key-value pairs will

--- a/Pod/Classes/LSSpan.m
+++ b/Pod/Classes/LSSpan.m
@@ -14,6 +14,9 @@
     bool m_errorFlag;
 }
 
+@synthesize traceId m_traceId;
+@synthesize spanId m_spanId;
+
 - (instancetype) initWithTracer:(LSTracer*)client {
     return [self initWithTracer:client
                   operationName:@""
@@ -63,12 +66,12 @@
             [m_tags setObject:[LSUtil hexGUID:parentId] forKey:@"parent_span_guid"];
         }
         if (traceId == 0) {
-            self->_traceId = [LSUtil generateGUID];
+            self->m_traceId = [LSUtil generateGUID];
         } else {
-            self->_traceId = traceId;
+            self->m_traceId = traceId;
         }
 
-        [self->m_tags setObject:[LSUtil hexGUID:self->_traceId] forKey:@"join:trace_guid"];
+        [self->m_tags setObject:[LSUtil hexGUID:self->m_traceId] forKey:@"join:trace_guid"];
 
         [self _addTags:tags];
     }
@@ -110,7 +113,7 @@
     // No locking is requied as all the member variables used below are immutable
     // after initialization:
     // - m_tracer
-    // - _spanId
+    // - m_spanId
 
     if (![m_tracer enabled]) {
         return;
@@ -121,7 +124,7 @@
     RLLogRecord* logRecord = [[RLLogRecord alloc]
                               initWithTimestamp_micros:[timestamp toMicros]
                               runtime_guid:[m_tracer runtimeGuid]
-                              span_guid:[LSUtil hexGUID:_spanId]
+                              span_guid:[LSUtil hexGUID:m_spanId]
                               stable_name:eventName
                               message:nil
                               level:@"I"
@@ -142,7 +145,7 @@
     // No locking is required as all the member variables used below are immutable
     // after initialization:
     // - m_tracer
-    // - _spanId
+    // - m_spanId
 
     if (![m_tracer enabled]) {
         return;
@@ -170,7 +173,7 @@
     RLLogRecord* logRecord = [[RLLogRecord alloc]
                               initWithTimestamp_micros:[[NSDate date] toMicros]
                               runtime_guid:[m_tracer runtimeGuid]
-                              span_guid:[LSUtil hexGUID:_spanId]
+                              span_guid:[LSUtil hexGUID:m_spanId]
                               stable_name:nil
                               message:message
                               level:@"E"
@@ -218,7 +221,7 @@
             }
         }
 
-        record = [[RLSpanRecord alloc] initWithSpan_guid:[LSUtil hexGUID:_spanId]
+        record = [[RLSpanRecord alloc] initWithSpan_guid:[LSUtil hexGUID:m_spanId]
                                             runtime_guid:m_tracer.runtimeGuid
                                                span_name:m_operationName
                                                 join_ids:nil
@@ -263,7 +266,7 @@
     int64_t now = [[NSDate date] toMicros];
     NSString* fmt = @"https://app.lightstep.com/%@/trace?span_guid=%@&at_micros=%@";
     NSString* accessToken = [[m_tracer accessToken] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    NSString* guid = [[LSUtil hexGUID:_spanId] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString* guid = [[LSUtil hexGUID:m_spanId] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSString* urlStr = [NSString stringWithFormat:fmt, accessToken, guid, @(now)];
     return [NSURL URLWithString:urlStr];
 }

--- a/Pod/Classes/LSSpan.m
+++ b/Pod/Classes/LSSpan.m
@@ -7,7 +7,6 @@
 
 @implementation LSSpan {
     LSTracer* m_tracer;
-    NSString* m_guid;
     NSString* m_operationName;
     NSDate* m_startTime;
     NSMutableDictionary* m_tags;
@@ -23,14 +22,34 @@
                       startTime:nil];
 }
 
-- (instancetype) initWithTracer:(LSTracer*)client
+- (instancetype) initWithTracer:(LSTracer*)tracer
                   operationName:(NSString*)operationName
                          parent:(LSSpan*)parent
                            tags:(NSDictionary*)tags
                       startTime:(NSDate*)startTime {
+    UInt64 traceId = 0;
+    UInt64 parentId = 0;
+    if (parent != nil) {
+        parentId = parent.spanId;
+        traceId = parent.traceId;
+    }
+    return [self initWithTracer:tracer
+                  operationName:operationName
+                        traceId:traceId
+                       parentId:parentId
+                           tags:tags
+                      startTime:startTime];
+}
+
+- (instancetype) initWithTracer:(LSTracer*)tracer
+                  operationName:(NSString*)operationName
+                        traceId:(UInt64)traceId
+                       parentId:(UInt64)parentId
+                           tags:(NSDictionary*)tags
+                      startTime:(NSDate*)startTime {
     if (self = [super init]) {
-        self->m_tracer = client;
-        self->m_guid = [LSUtil generateGUID];
+        self->m_tracer = tracer;
+        self->_spanId = [LSUtil generateGUID];
         self->m_operationName = operationName;
         self->m_startTime = startTime;
         self->m_tags = [NSMutableDictionary dictionary];
@@ -40,9 +59,17 @@
         if (startTime == nil) {
             m_startTime = [NSDate date];
         }
-        if (parent != nil) {
-            [m_tags setObject:parent->m_guid forKey:@"parent_span_guid"];
+        if (parentId != 0) {
+            [m_tags setObject:[LSUtil hexGUID:parentId] forKey:@"parent_span_guid"];
         }
+        if (traceId == 0) {
+            self->_traceId = [LSUtil generateGUID];
+        } else {
+            self->_traceId = traceId;
+        }
+
+        [self->m_tags setObject:[LSUtil hexGUID:self->_traceId] forKey:@"join:trace_guid"];
+
         [self _addTags:tags];
     }
     return self;
@@ -83,7 +110,7 @@
     // No locking is requied as all the member variables used below are immutable
     // after initialization:
     // - m_tracer
-    // - m_guid
+    // - _spanId
 
     if (![m_tracer enabled]) {
         return;
@@ -94,7 +121,7 @@
     RLLogRecord* logRecord = [[RLLogRecord alloc]
                               initWithTimestamp_micros:[timestamp toMicros]
                               runtime_guid:[m_tracer runtimeGuid]
-                              span_guid:m_guid
+                              span_guid:[LSUtil hexGUID:_spanId]
                               stable_name:eventName
                               message:nil
                               level:@"I"
@@ -112,10 +139,10 @@
 // NOTE: logError is a LightStep-specific method
 //
 - (void)logError:(NSString*)message error:(NSObject*)errorOrException {
-    // No locking is requied as all the member variables used below are immutable
+    // No locking is required as all the member variables used below are immutable
     // after initialization:
     // - m_tracer
-    // - m_guid
+    // - _spanId
 
     if (![m_tracer enabled]) {
         return;
@@ -143,7 +170,7 @@
     RLLogRecord* logRecord = [[RLLogRecord alloc]
                               initWithTimestamp_micros:[[NSDate date] toMicros]
                               runtime_guid:[m_tracer runtimeGuid]
-                              span_guid:m_guid
+                              span_guid:[LSUtil hexGUID:_spanId]
                               stable_name:nil
                               message:message
                               level:@"E"
@@ -186,12 +213,12 @@
         if (m_tags.count > 0) {
             tagArray = [[NSMutableArray alloc] initWithCapacity:m_tags.count];
             for (NSString* key in m_tags ) {
-                RLKeyValue* pair = [[RLKeyValue alloc] initWithKey:key Value:m_tags[key]];
+                RLKeyValue* pair = [[RLKeyValue alloc] initWithKey:key Value:[m_tags[key] description]];
                 [tagArray addObject:pair];
             }
         }
 
-        record = [[RLSpanRecord alloc] initWithSpan_guid:m_guid
+        record = [[RLSpanRecord alloc] initWithSpan_guid:[LSUtil hexGUID:_spanId]
                                             runtime_guid:m_tracer.runtimeGuid
                                                span_name:m_operationName
                                                 join_ids:nil
@@ -209,10 +236,6 @@
 }
 
 
-- (NSString*)guid {
-    return m_guid;
-}
-
 - (void)_addTags:(NSDictionary*)tags {
     if (tags == nil) {
         return;
@@ -228,11 +251,19 @@
     }
 }
 
+- (NSString*) hexTraceId {
+    return [LSUtil hexGUID:self.traceId];
+}
+
+- (NSString*) hexSpanId {
+    return [LSUtil hexGUID:self.spanId];
+}
+
 - (NSURL*)_generateTraceURL {
     int64_t now = [[NSDate date] toMicros];
     NSString* fmt = @"https://app.lightstep.com/%@/trace?span_guid=%@&at_micros=%@";
     NSString* accessToken = [[m_tracer accessToken] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-    NSString* guid = [m_guid stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString* guid = [[LSUtil hexGUID:_spanId] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSString* urlStr = [NSString stringWithFormat:fmt, accessToken, guid, @(now)];
     return [NSURL URLWithString:urlStr];
 }

--- a/Pod/Classes/LSTracer.h
+++ b/Pod/Classes/LSTracer.h
@@ -3,9 +3,13 @@
 #import "crouton.h"
 #import "LSSpan.h"
 
-FOUNDATION_EXPORT NSString *const LSFormatSplitText;
+FOUNDATION_EXPORT NSString *const OTFormatTextMap;
+FOUNDATION_EXPORT NSString *const OTFormatBinary;
 
-FOUNDATION_EXPORT NSString *const LSFormatBinary;
+FOUNDATION_EXPORT NSString *const OTErrorDomain;
+FOUNDATION_EXPORT NSInteger OTUnsupportedFormatCode;
+FOUNDATION_EXPORT NSInteger OTInvalidCarrierCode;
+FOUNDATION_EXPORT NSInteger OTTraceCorruptedCode;
 
 /**
  * The entrypoint to instrumentation for Cocoa.
@@ -101,7 +105,8 @@ FOUNDATION_EXPORT NSString *const LSFormatBinary;
 /**
  * Transfer the span information into the carrier of the given format.
  */
-- (void)inject:(LSSpan*)span format:(NSString*)format carrier:(id)carrier;
+- (bool)inject:(LSSpan*)span format:(NSString*)format carrier:(id)carrier;
+- (bool)inject:(LSSpan*)span format:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError;
 
 /**
  * Create a new span from the carrier of the given format.

--- a/Pod/Classes/LSTracer.h
+++ b/Pod/Classes/LSTracer.h
@@ -3,6 +3,8 @@
 #import "crouton.h"
 #import "LSSpan.h"
 
+// Note: using the OT prefix here because these symbols belong in
+// `opentracing-objc` and it will make future migrations a tiny bit easier.
 FOUNDATION_EXPORT NSString *const OTFormatTextMap;
 FOUNDATION_EXPORT NSString *const OTFormatBinary;
 
@@ -104,14 +106,21 @@ FOUNDATION_EXPORT NSInteger OTTraceCorruptedCode;
 
 /**
  * Transfer the span information into the carrier of the given format.
+ *
+ * For example:
+ *
+ *     NSMutableDictionary* httpHeaders = ...
+ *     [[LSTracer sharedTracer] inject:span format:OTFormatTextMap carrier:headers];
+ *
  */
 - (bool)inject:(LSSpan*)span format:(NSString*)format carrier:(id)carrier;
 - (bool)inject:(LSSpan*)span format:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError;
 
 /**
- * Create a new span from the carrier of the given format.
+ * Create a new span joined to the trace (remotely) injected into the carrier of the given format.
  */
 - (LSSpan*)join:(NSString*)operationName format:(NSString*)format carrier:(id)carrier;
+- (LSSpan*)join:(NSString*)operationName format:(NSString*)format carrier:(id)carrier error:(NSError* __autoreleasing *)outError;
 
 #pragma mark - LightStep extensions and internal methods
 

--- a/Pod/Classes/LSUtil.h
+++ b/Pod/Classes/LSUtil.h
@@ -5,7 +5,9 @@
  */
 @interface LSUtil : NSObject
 
-+ (NSString*)generateGUID;
++ (UInt64)generateGUID;
++ (NSString*)hexGUID:(UInt64)guid;
++ (UInt64)guidFromHex:(NSString*)hexString;
 + (NSString*)objectToJSONString:(id)obj maxLength:(NSUInteger)maxLength;
 
 @end

--- a/Pod/Classes/LSUtil.m
+++ b/Pod/Classes/LSUtil.m
@@ -3,8 +3,21 @@
 
 @implementation LSUtil
 
-+ (NSString*)generateGUID {
-    return [NSString stringWithFormat:@"%x%x", arc4random(), arc4random()];
++ (UInt64)generateGUID {
+    return (((UInt64)arc4random()) << 32) | arc4random();
+}
+
++ (NSString*)hexGUID:(UInt64)guid {
+    return [NSString stringWithFormat:@"%llx", guid];
+}
+
++ (UInt64)guidFromHex:(NSString*)hexString {
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    UInt64 rval;
+    if (![scanner scanHexLongLong:&rval]) {
+        return 0; // what else to do?
+    }
+    return rval;
 }
 
 + (NSString*)objectToJSONString:(id)obj

--- a/examples/LightStepTestUI/LightStepTestUI/ViewController.m
+++ b/examples/LightStepTestUI/LightStepTestUI/ViewController.m
@@ -123,8 +123,7 @@ completionHandler:(void (^)(id response, NSError *error))completionHandler {
     NSMutableDictionary* headers = [NSMutableDictionary dictionaryWithDictionary:[config HTTPAdditionalHeaders]];
     [headers setObject:@"LightStep iOS Example" forKey:@"User-Agent"];
     [headers setObject:span.tracer.accessToken forKey:@"LightStep-Access-Token"];
-    [headers setObject:span.traceGUID forKey:@"LightStep-Trace-GUID" ];
-    [headers setObject:span.guid forKey:@"LightStep-Parent-GUID"];
+    [[LSTracer sharedTracer] inject:span format:OTFormatTextMap carrier:headers];
     config.HTTPAdditionalHeaders = headers;
 
     NSURLComponents* urlComponents = [NSURLComponents new];


### PR DESCRIPTION
The changes here make the Objective-C tracer `basictracer`-compatible for the text format. The binary format requires protobuf gencode (or some major-league bit-twiddling) so will have to wait a bit.
