### PR TITLE
Update the code to use the trace_guid field

### DIFF
--- a/Pod/Classes/LSSpan.m
+++ b/Pod/Classes/LSSpan.m
@@ -70,8 +70,6 @@
             self->m_traceId = traceId;
         }
 
-        [self->m_tags setObject:[LSUtil hexGUID:self->m_traceId] forKey:@"join:trace_guid"];
-
         [self _addTags:tags];
     }
     return self;
@@ -221,6 +219,7 @@
         }
 
         record = [[RLSpanRecord alloc] initWithSpan_guid:[LSUtil hexGUID:m_spanId]
+                                              trace_guid:[LSUtil hexGUID:m_traceId]
                                             runtime_guid:m_tracer.runtimeGuid
                                                span_name:m_operationName
                                                 join_ids:nil
@@ -234,7 +233,7 @@
 }
 
 - (NSString*)traceGUID {
-    return [m_tags objectForKey:@"join:trace_guid"];
+    return [LSUtil hexGUID:m_traceId];
 }
 
 - (void)setSpanId:(UInt64)spanId {

--- a/Pod/Classes/crouton.h
+++ b/Pod/Classes/crouton.h
@@ -323,6 +323,7 @@
 
 @interface RLSpanRecord : NSObject <TBase, NSCoding> {
   NSString * __span_guid;
+  NSString * __trace_guid;
   NSString * __runtime_guid;
   NSString * __span_name;
   NSMutableArray * __join_ids;
@@ -333,6 +334,7 @@
   NSMutableArray * __log_records;
 
   BOOL __span_guid_isset;
+  BOOL __trace_guid_isset;
   BOOL __runtime_guid_isset;
   BOOL __span_name_isset;
   BOOL __join_ids_isset;
@@ -346,6 +348,8 @@
 #if TARGET_OS_IPHONE || (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
 @property (nonatomic, retain, getter=span_guid, setter=setSpan_guid:) NSString * span_guid;
 - (void) unsetSpan_guid;
+@property (nonatomic, retain, getter=trace_guid, setter=setTrace_guid:) NSString * trace_guid;
+- (void) unsetTrace_guid;
 @property (nonatomic, retain, getter=runtime_guid, setter=setRuntime_guid:) NSString * runtime_guid;
 - (void) unsetRuntime_guid;
 @property (nonatomic, retain, getter=span_name, setter=setSpan_name:) NSString * span_name;
@@ -365,7 +369,7 @@
 #endif
 
 - (id) init;
-- (id) initWithSpan_guid: (NSString *) span_guid runtime_guid: (NSString *) runtime_guid span_name: (NSString *) span_name join_ids: (NSMutableArray *) join_ids oldest_micros: (int64_t) oldest_micros youngest_micros: (int64_t) youngest_micros attributes: (NSMutableArray *) attributes error_flag: (BOOL) error_flag log_records: (NSMutableArray *) log_records;
+- (id) initWithSpan_guid: (NSString *) span_guid trace_guid: (NSString *) trace_guid runtime_guid: (NSString *) runtime_guid span_name: (NSString *) span_name join_ids: (NSMutableArray *) join_ids oldest_micros: (int64_t) oldest_micros youngest_micros: (int64_t) youngest_micros attributes: (NSMutableArray *) attributes error_flag: (BOOL) error_flag log_records: (NSMutableArray *) log_records;
 
 - (void) read: (id <TProtocol>) inProtocol;
 - (void) write: (id <TProtocol>) outProtocol;
@@ -377,6 +381,12 @@
 - (void) setSpan_guid: (NSString *) span_guid;
 #endif
 - (BOOL) span_guidIsSet;
+
+#if !__has_feature(objc_arc)
+- (NSString *) trace_guid;
+- (void) setTrace_guid: (NSString *) trace_guid;
+#endif
+- (BOOL) trace_guidIsSet;
 
 #if !__has_feature(objc_arc)
 - (NSString *) runtime_guid;

--- a/Pod/Classes/crouton.m
+++ b/Pod/Classes/crouton.m
@@ -1513,11 +1513,13 @@
   return self;
 }
 
-- (id) initWithSpan_guid: (NSString *) span_guid runtime_guid: (NSString *) runtime_guid span_name: (NSString *) span_name join_ids: (NSMutableArray *) join_ids oldest_micros: (int64_t) oldest_micros youngest_micros: (int64_t) youngest_micros attributes: (NSMutableArray *) attributes error_flag: (BOOL) error_flag log_records: (NSMutableArray *) log_records
+- (id) initWithSpan_guid: (NSString *) span_guid trace_guid: (NSString *) trace_guid runtime_guid: (NSString *) runtime_guid span_name: (NSString *) span_name join_ids: (NSMutableArray *) join_ids oldest_micros: (int64_t) oldest_micros youngest_micros: (int64_t) youngest_micros attributes: (NSMutableArray *) attributes error_flag: (BOOL) error_flag log_records: (NSMutableArray *) log_records
 {
   self = [super init];
   __span_guid = [span_guid retain_stub];
   __span_guid_isset = YES;
+  __trace_guid = [trace_guid retain_stub];
+  __trace_guid_isset = YES;
   __runtime_guid = [runtime_guid retain_stub];
   __runtime_guid_isset = YES;
   __span_name = [span_name retain_stub];
@@ -1544,6 +1546,11 @@
   {
     __span_guid = [[decoder decodeObjectForKey: @"span_guid"] retain_stub];
     __span_guid_isset = YES;
+  }
+  if ([decoder containsValueForKey: @"trace_guid"])
+  {
+    __trace_guid = [[decoder decodeObjectForKey: @"trace_guid"] retain_stub];
+    __trace_guid_isset = YES;
   }
   if ([decoder containsValueForKey: @"runtime_guid"])
   {
@@ -1594,6 +1601,10 @@
   {
     [encoder encodeObject: __span_guid forKey: @"span_guid"];
   }
+  if (__trace_guid_isset)
+  {
+    [encoder encodeObject: __trace_guid forKey: @"trace_guid"];
+  }
   if (__runtime_guid_isset)
   {
     [encoder encodeObject: __runtime_guid forKey: @"runtime_guid"];
@@ -1631,6 +1642,7 @@
 - (void) dealloc
 {
   [__span_guid release_stub];
+  [__trace_guid release_stub];
   [__runtime_guid release_stub];
   [__span_name release_stub];
   [__join_ids release_stub];
@@ -1658,6 +1670,27 @@
   [__span_guid release_stub];
   __span_guid = nil;
   __span_guid_isset = NO;
+}
+
+- (NSString *) trace_guid {
+  return [[__trace_guid retain_stub] autorelease_stub];
+}
+
+- (void) setTrace_guid: (NSString *) trace_guid {
+  [trace_guid retain_stub];
+  [__trace_guid release_stub];
+  __trace_guid = trace_guid;
+  __trace_guid_isset = YES;
+}
+
+- (BOOL) trace_guidIsSet {
+  return __trace_guid_isset;
+}
+
+- (void) unsetTrace_guid {
+  [__trace_guid release_stub];
+  __trace_guid = nil;
+  __trace_guid_isset = NO;
 }
 
 - (NSString *) runtime_guid {
@@ -1839,6 +1872,14 @@
           [TProtocolUtil skipType: fieldType onProtocol: inProtocol];
         }
         break;
+      case 11:
+        if (fieldType == TType_STRING) {
+          NSString * fieldValue = [inProtocol readString];
+          [self setTrace_guid: fieldValue];
+        } else { 
+          [TProtocolUtil skipType: fieldType onProtocol: inProtocol];
+        }
+        break;
       case 2:
         if (fieldType == TType_STRING) {
           NSString * fieldValue = [inProtocol readString];
@@ -1957,6 +1998,13 @@
       [outProtocol writeFieldEnd];
     }
   }
+  if (__trace_guid_isset) {
+    if (__trace_guid != nil) {
+      [outProtocol writeFieldBeginWithName: @"trace_guid" type: TType_STRING fieldID: 11];
+      [outProtocol writeString: __trace_guid];
+      [outProtocol writeFieldEnd];
+    }
+  }
   if (__runtime_guid_isset) {
     if (__runtime_guid != nil) {
       [outProtocol writeFieldBeginWithName: @"runtime_guid" type: TType_STRING fieldID: 2];
@@ -2043,6 +2091,8 @@
   NSMutableString * ms = [NSMutableString stringWithString: @"RLSpanRecord("];
   [ms appendString: @"span_guid:"];
   [ms appendFormat: @"\"%@\"", __span_guid];
+  [ms appendString: @",trace_guid:"];
+  [ms appendFormat: @"\"%@\"", __trace_guid];
   [ms appendString: @",runtime_guid:"];
   [ms appendFormat: @"\"%@\"", __runtime_guid];
   [ms appendString: @",span_name:"];


### PR DESCRIPTION
- Updates the iOS code to the latest Thrift protocol file
- Uses the `trace_guid` field rather than a `join:trace_guid`
