### PR TITLE
Move references to crouton.h out of the public headers

### DIFF
--- a/Pod/Classes/LSSpan.h
+++ b/Pod/Classes/LSSpan.h
@@ -1,6 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "crouton.h"
 #import <opentracing/OTSpan.h>
 
 @class LSTracer;

--- a/Pod/Classes/LSSpan.m
+++ b/Pod/Classes/LSSpan.m
@@ -1,5 +1,6 @@
 #import "LSSpan.h"
 #import "LSTracer.h"
+#import "LSTracerInternal.h"
 #import "LSUtil.h"
 
 #pragma mark - LSSpan

--- a/Pod/Classes/LSTracer.h
+++ b/Pod/Classes/LSTracer.h
@@ -1,6 +1,5 @@
 #import <Foundation/Foundation.h>
 
-#import "crouton.h"
 #import "LSSpan.h"
 #import "opentracing/OTTracer.h"
 
@@ -160,16 +159,5 @@
  * Flush any buffered data to the collector.
  */
 - (void)flush;
-
-/**
- * Record a span.
- */
-- (void) _appendSpanRecord:(RLSpanRecord*)spanRecord;
-
-/**
- * Record a log record.
- */
-- (void) _appendLogRecord:(RLLogRecord*)logRecord;
-
 
 @end

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import "LSVersion.h"
 #import "LSTracer.h"
+#import "LSTracerInternal.h"
 #import "LSSpan.h"
 #import "LSUtil.h"
 #import "LSClockState.h"

--- a/Pod/Classes/LSTracerInternal.h
+++ b/Pod/Classes/LSTracerInternal.h
@@ -1,0 +1,18 @@
+// Move references to the Thrift internals here to avoid exposing the details
+// in the public headers. This is not merely a code cleanliness issue as the
+// added interfaces can affect Xcode's type resolution.
+#import "crouton.h"
+
+@interface LSTracer ()
+
+/**
+ * Record a span.
+ */
+- (void) _appendSpanRecord:(RLSpanRecord*)spanRecord;
+
+/**
+ * Record a log record.
+ */
+- (void) _appendLogRecord:(RLLogRecord*)logRecord;
+
+@end

--- a/examples/LightStepTestUI/LightStepTestUI.xcodeproj/project.pbxproj
+++ b/examples/LightStepTestUI/LightStepTestUI.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		8141310B1C8FDC5500E6D12C /* LSUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LSUtil.h; path = ../../../Pod/Classes/LSUtil.h; sourceTree = "<group>"; };
 		8141310C1C8FDC5500E6D12C /* LSUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = LSUtil.m; path = ../../../Pod/Classes/LSUtil.m; sourceTree = "<group>"; };
 		814131121C90967200E6D12C /* LSVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LSVersion.h; path = ../../../Pod/Classes/LSVersion.h; sourceTree = "<group>"; };
+		816919D21D2DAC08001638A0 /* LSTracerInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = LSTracerInternal.h; path = ../../../Pod/Classes/LSTracerInternal.h; sourceTree = "<group>"; };
 		817C861B1C84D0200060C5FD /* LightStepUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LightStepUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		817C861D1C84D0200060C5FD /* LightStepUnitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LightStepUnitTests.m; sourceTree = "<group>"; };
 		817C861F1C84D0200060C5FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -154,6 +155,7 @@
 				814131081C8FDC5500E6D12C /* LSSpan.m */,
 				814131121C90967200E6D12C /* LSVersion.h */,
 				814131091C8FDC5500E6D12C /* LSTracer.h */,
+				816919D21D2DAC08001638A0 /* LSTracerInternal.h */,
 				8141310A1C8FDC5500E6D12C /* LSTracer.m */,
 				8141310B1C8FDC5500E6D12C /* LSUtil.h */,
 				8141310C1C8FDC5500E6D12C /* LSUtil.m */,


### PR DESCRIPTION
## Summary

The public `LSTracer.h` header was referencing an internal header (`crouton.h`) that contains implementation details.

One of the side-effects was that the internal header has a method named `count` which has a different return type than the "standard" `NSDictionary` `count` method - which can cause return type resolution issues when using `ids`.

The fix is to move the internal header references out of the public headers (and use a [class extension](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/CustomizingExistingClasses/CustomizingExistingClasses.html) for the internal uses).
