### PR TITLE
Fix UInt64/SInt64 wreckage

### DIFF
--- a/Pod/Classes/LSClockState.h
+++ b/Pod/Classes/LSClockState.h
@@ -2,8 +2,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class LSTracer;
-
 /**
  * A straight port/copy of the `rl-cruntime-common` ClockState javascript 
  * prototype.
@@ -11,9 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface LSClockState : NSObject
 
 // A helper that returns the local timestamp in microseconds (since the unix epoch).
-+ (UInt64) nowMicros;
-
-- (id) initWithLSTracer:(LSTracer*)tracer;
++ (SInt64) nowMicros;
 
 /** 
  * Provide information about a fresh clock-skew datapoint.
@@ -30,10 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * All timestamps are in microseconds.
  */
-- (void) addSampleWithOriginMicros:(UInt64)originMicros
-                     receiveMicros:(UInt64)receiveMicros
-                    transmitMicros:(UInt64)transmitMicros
-                 destinationMicros:(UInt64)destinationMicros;
+- (void) addSampleWithOriginMicros:(SInt64)originMicros
+                     receiveMicros:(SInt64)receiveMicros
+                    transmitMicros:(SInt64)transmitMicros
+                 destinationMicros:(SInt64)destinationMicros;
 
 /** 
  * Force an update of the internal clock-skew machinery.
@@ -45,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  * client in microseconds. This should be *added* to any local timestamps before
  * sending to the server.
  */
-- (UInt64) offsetMicros;
+- (SInt64) offsetMicros;
 
 @end
 

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -70,7 +70,7 @@ static LSTracer* s_sharedInstance = nil;
         self->m_flushQueue = dispatch_queue_create("com.lightstep.flush_queue", DISPATCH_QUEUE_SERIAL);
         self->m_flushTimer = nil;
         self->m_enabled = true;  // if false, no longer collect tracing data
-        self->m_clockState = [[LSClockState alloc] initWithLSTracer:self];
+        self->m_clockState = [[LSClockState alloc] init];
         self->m_lastFlush = [NSDate date];
         self->m_bgTaskId = UIBackgroundTaskInvalid;
 
@@ -404,11 +404,11 @@ static NSString* kBasicTracerBaggagePrefix = @"ot-baggage-";
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
     request.HTTPBody = [reqBody dataUsingEncoding:NSUTF8StringEncoding];
     request.HTTPMethod = @"POST";
-    UInt64 originMicros = [LSClockState nowMicros];
+    SInt64 originMicros = [LSClockState nowMicros];
     NSURLSessionDataTask *postDataTask = [session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         @try {
             __typeof__(self) strongSelf = weakSelf;
-            UInt64 destinationMicros = [LSClockState nowMicros];
+            SInt64 destinationMicros = [LSClockState nowMicros];
             NSError* jsonError;
             NSDictionary* responseJSON = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:&jsonError];
             if (jsonError == nil) {


### PR DESCRIPTION
This bug predated the GRPC-ectomy and is pretty terrible. Basically resulted in timing adjustments to the tune of `2^63` microseconds (which is a long time).