### PR TITLE
Crashes

### DIFF
--- a/Pod/Classes/LSClockState.m
+++ b/Pod/Classes/LSClockState.m
@@ -49,12 +49,15 @@ static NSString *kSamplesKey = @"samples";
 @property(nonatomic, strong) NSMutableArray<LSSyncSample *> *samples;
 @property(nonatomic) NSInteger currentOffsetAge;
 @property(nonatomic) SInt64 currentOffsetMicros;
+@property(nonatomic) dispatch_queue_t samplesQueue;
 @end
 
 @implementation LSClockState
 
 - (id)init {
     if (self = [super init]) {
+        _samplesQueue = dispatch_queue_create("sample storage", DISPATCH_QUEUE_SERIAL);
+
         [self _tryToRestoreFromUserDefaults];
         [self update];
     }
@@ -73,6 +76,7 @@ static NSString *kSamplesKey = @"samples";
                     receiveMicros:(SInt64)receiveMicros
                    transmitMicros:(SInt64)transmitMicros
                 destinationMicros:(SInt64)destinationMicros {
+
     SInt64 latestDelayMicros = INT64_MAX;
     SInt64 latestOffsetMicros = 0;
     // Ensure that all of the data are valid before using them. If
@@ -82,18 +86,20 @@ static NSString *kSamplesKey = @"samples";
         latestOffsetMicros = ((receiveMicros - originMicros) + (transmitMicros - destinationMicros)) / 2;
     }
 
-    // Discard the oldest sample and push the new one.
-    [self.samples removeObjectAtIndex:0];
-    [self.samples
-        addObject:[[LSSyncSample alloc] initWithDelayMicros:latestDelayMicros offsetMicros:latestOffsetMicros]];
+    dispatch_async(self.samplesQueue, ^{
+        // Discard the oldest sample and push the new one.
+        [self.samples removeObjectAtIndex:0];
+        [self.samples
+         addObject:[[LSSyncSample alloc] initWithDelayMicros:latestDelayMicros offsetMicros:latestOffsetMicros]];
 
-    self.currentOffsetAge++;
+        self.currentOffsetAge++;
 
-    // Remember what we've seen.
-    [self _persistToUserDefaults];
-
-    // Take the new sample into account.
-    [self update];
+        // Remember what we've seen.
+        [self _persistSamplesToUserDefaults:self.samples.copy];
+        
+        // Take the new sample into account.
+        [self update];
+    });
 }
 
 - (void)update {
@@ -149,24 +155,23 @@ static NSString *kSamplesKey = @"samples";
 
 #pragma mark - Private
 
-- (void)_persistToUserDefaults {
+- (void)_persistSamplesToUserDefaults:(NSArray *)samples {
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:@{
         kTimestampMicrosKey: @([LSClockState nowMicros]),
-        kSamplesKey: self.samples
+        kSamplesKey: samples
     }];
     [[NSUserDefaults standardUserDefaults] setObject:data forKey:kUserDefaultsKey];
 }
 
 // Overwrites all state; only intended to be called from init.
 - (void)_tryToRestoreFromUserDefaults {
-    self.samples = [NSMutableArray array];
-    self.currentOffsetMicros = 0;
-    self.currentOffsetAge = kMaxOffsetAge + 1;
-    NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:kUserDefaultsKey];
-    if (data != nil) {
-        // Check out this gem, which ends with an emphatic "*Do not use NSKeyedArchiver*":
-        // http://stackoverflow.com/a/17301208/3399080
-        @try {
+    dispatch_sync(self.samplesQueue, ^{
+        self.currentOffsetMicros = 0;
+        self.currentOffsetAge = kMaxOffsetAge + 1;
+        NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:kUserDefaultsKey];
+        if (data != nil) {
+            // Check out this gem, which ends with an emphatic "*Do not use NSKeyedArchiver*":
+            // http://stackoverflow.com/a/17301208/3399080
             NSDictionary *dict = [NSKeyedUnarchiver unarchiveObjectWithData:data];
             NSNumber *tsMicros = [dict objectForKey:kTimestampMicrosKey];
             NSArray *samples = [dict objectForKey:kSamplesKey];
@@ -175,19 +180,20 @@ static NSString *kSamplesKey = @"samples";
                 (tsMicros.longLongValue < nowMicros) /* <-- sanity check */) {
                 NSUInteger loc = MAX(0, (NSInteger)samples.count - (kMaxOffsetAge + 1));
                 NSUInteger len = samples.count - loc;
-                self.samples = [NSMutableArray arrayWithArray:[samples subarrayWithRange:NSMakeRange(loc, len)]];
+                self.samples = [samples subarrayWithRange:NSMakeRange(loc, len)].mutableCopy;
             }
-        } @catch (NSException *e) {
-            NSLog(@"Unable to decode LSClockState data. Leaving things be.");
+        } else {
+            self.samples = [NSMutableArray new];
         }
-    }
-    if (self.samples.count == 0) {
-        // Otherwise initalize with (kMaxOffsetAge+1) dummy samples.
-        for (int i = 0; i < (kMaxOffsetAge + 1); i++) {
-            LSSyncSample *ss = [[LSSyncSample alloc] initWithDelayMicros:INT64_MAX offsetMicros:0];
-            [self.samples addObject:ss];
+
+        if (self.samples.count == 0) {
+            // Otherwise initalize with (kMaxOffsetAge+1) dummy samples.
+            for (int i = 0; i < (kMaxOffsetAge + 1); i++) {
+                LSSyncSample *ss = [[LSSyncSample alloc] initWithDelayMicros:INT64_MAX offsetMicros:0];
+                [self.samples addObject:ss];
+            }
         }
-    }
+    });
 }
 
 @end

--- a/Pod/Classes/LSClockState.m
+++ b/Pod/Classes/LSClockState.m
@@ -173,7 +173,7 @@ static NSString *kSamplesKey = @"samples";
             SInt64 nowMicros = [LSClockState nowMicros];
             if (dict && tsMicros && samples && (tsMicros.longLongValue > (nowMicros - kStoredSamplesTTLMicros)) &&
                 (tsMicros.longLongValue < nowMicros) /* <-- sanity check */) {
-                NSUInteger loc = MAX(0, samples.count - (kMaxOffsetAge + 1));
+                NSUInteger loc = MAX(0, (NSInteger)samples.count - (kMaxOffsetAge + 1));
                 NSUInteger len = samples.count - loc;
                 self.samples = [NSMutableArray arrayWithArray:[samples subarrayWithRange:NSMakeRange(loc, len)]];
             }

--- a/Pod/Classes/LSClockState.m
+++ b/Pod/Classes/LSClockState.m
@@ -86,6 +86,8 @@ static NSString *kSamplesKey = @"samples";
         latestOffsetMicros = ((receiveMicros - originMicros) + (transmitMicros - destinationMicros)) / 2;
     }
 
+
+    // Note that self.samplesQueue is DISPATCH_QUEUE_SERIAL and it makes thread safe reads/writes.
     dispatch_async(self.samplesQueue, ^{
         // Discard the oldest sample and push the new one.
         [self.samples removeObjectAtIndex:0];
@@ -96,7 +98,7 @@ static NSString *kSamplesKey = @"samples";
 
         // Remember what we've seen.
         [self _persistSamplesToUserDefaults:self.samples.copy];
-        
+
         // Take the new sample into account.
         [self update];
     });

--- a/Pod/Classes/LSTracer.h
+++ b/Pod/Classes/LSTracer.h
@@ -59,6 +59,9 @@ extern NSInteger const LSBackgroundTaskError;
 /// `LSTracer` instance's globally unique id ("guid"), and assigned automatically by LightStep.
 @property(nonatomic, readonly) UInt64 runtimeGuid;
 
+/// HTTP session to be used for performing requests. This enable sharing a connnection pool with your own app.
+@property(nonatomic, strong) NSURLSession *urlSession;
+
 /// The `LSTracer` instance's maximum number of records to buffer between reports.
 @property(atomic) NSUInteger maxSpanRecords;
 

--- a/Pod/Classes/LSTracer.h
+++ b/Pod/Classes/LSTracer.h
@@ -59,7 +59,8 @@ extern NSInteger const LSBackgroundTaskError;
 /// `LSTracer` instance's globally unique id ("guid"), and assigned automatically by LightStep.
 @property(nonatomic, readonly) UInt64 runtimeGuid;
 
-/// HTTP session to be used for performing requests. This enable sharing a connnection pool with your own app.
+/// HTTP session to be used for performing requests. This enables sharing a connnection pool with your own app.
+/// It should be set during initialization, ideally before starting and finishing Spans.
 @property(nonatomic, strong) NSURLSession *urlSession;
 
 /// The `LSTracer` instance's maximum number of records to buffer between reports.

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -339,7 +339,9 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
     NSString *reqBody = [LSUtil objectToJSONString:reqJSON maxLength:LSMaxRequestSize];
     if (reqBody == nil) {
         cleanupBlock(true, [NSError errorWithDomain:LSErrorDomain code:LSRequestTooLargeError userInfo:nil]);
+        return;
     }
+
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.baseURL];
     request.allHTTPHeaderFields = @{
         @"Content-Type": @"application/json",

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -320,7 +320,7 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
         reqJSON[@"oldest_micros"] = @([self.lastFlush toMicros]);
         reqJSON[@"youngest_micros"] = @([now toMicros]);
 
-        self.pendingJSONSpans = [NSMutableArray<NSDictionary *> array];
+        self.pendingJSONSpans = [NSMutableArray<NSDictionary *> new];
         self.lastFlush = now;
 
         self.bgTaskId = [[UIApplication sharedApplication]


### PR DESCRIPTION
We're currently observing some crashes in production, mostly reported as EXC_BAD_ACCESS (accessing garbage memory).

The diff is reviewable commit by commit, but in a nutshell:
- integer overflow bug is fixed
- we're adding a dispatch queue for accessing self.samples instead of relying on locking. The current code throws when self.examples are being mutated while copied
- HTTP sessions are reused (and shareable) with your main app, instead of making one HTTP session per each request
- @try/catch is removed in favor of early bailing out if data passed to NSJSONSerialization is nil. This is a design flaw in Objc/Foundation where a method takes an error pointer but also throws exceptions. Exceptions are a known cause of memory leaks in Objc and should be avoided.
- A missing return is added here https://github.com/lightstep/lightstep-tracer-objc/compare/master...supermarin:crashes?expand=1#diff-dcd31561a7bbcafcbdeb70ddd1ba0b08R342
- Reduces the number of autoreleased allocations in favor of immediate releasing