### PR TITLE
Fix self.samples initialization

### DIFF
--- a/Pod/Classes/LSClockState.m
+++ b/Pod/Classes/LSClockState.m
@@ -184,8 +184,6 @@ static NSString *kSamplesKey = @"samples";
                 NSUInteger len = samples.count - loc;
                 self.samples = [samples subarrayWithRange:NSMakeRange(loc, len)].mutableCopy;
             }
-        } else {
-            self.samples = [NSMutableArray new];
         }
 
         if (self.samples.count == 0) {
@@ -195,6 +193,8 @@ static NSString *kSamplesKey = @"samples";
                 [self.samples addObject:ss];
             }
         }
+
+        self.samples = _samples ?: [NSMutableArray new];
     });
 }
 


### PR DESCRIPTION
Introduced a problem in 3.2.8 and discovered after testing with our own app.
The SDK crashes if there was no samples previously recorded