### PR TITLE
Update invalid docstrings

### DIFF
--- a/Pod/Classes/LSClockState.h
+++ b/Pod/Classes/LSClockState.h
@@ -13,15 +13,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Provide information about a fresh clock-skew datapoint.
 ///
-/// @param originMicros: represents the local time of transmission.
+/// @param originMicros represents the local time of transmission.
 ///
-/// @param receiveMicros: represents the time the remote server received the synchronization message
+/// @param receiveMicros represents the time the remote server received the synchronization message
 ///                       (according to the server's clock).
 ///
-/// @param receiveMicros: represents the time the remote server sent the synchronization reply
+/// @param transmitMicros represents the time the remote server sent the synchronization reply
 ///                       (according to the server's clock).
 ///
-/// @param destinationMicros: represents the local time of receipt for the synchronization reply.
+/// @param destinationMicros represents the local time of receipt for the synchronization reply.
 - (void)addSampleWithOriginMicros:(SInt64)originMicros
                     receiveMicros:(SInt64)receiveMicros
                    transmitMicros:(SInt64)transmitMicros

--- a/Pod/Classes/LSTracer.h
+++ b/Pod/Classes/LSTracer.h
@@ -38,11 +38,11 @@ extern NSInteger const LSBackgroundTaskError;
 /// wish to register for UIApplicationDidEnterBackgroundNotification notifications and explicitly call flush
 /// at that point.
 ///
-/// @param accessToken: the access token.
-/// @param componentName: the "component name" to associate with spans from this process; e.g.,
-///                       the name of your iOS app or the bundle name.
-/// @param baseURL: the URL for the collector's HTTP+JSON base endpoint (search for LSDefaultBaseURLString)
-/// @param flushIntervalSeconds: the flush interval, or 0 for no automatic background flushing
+/// @param accessToken the access token.
+/// @param componentName the "component name" to associate with spans from this process; e.g.,
+///                      the name of your iOS app or the bundle name.
+/// @param baseURL the URL for the collector's HTTP+JSON base endpoint (search for LSDefaultBaseURLString)
+/// @param flushIntervalSeconds the flush interval, or 0 for no automatic background flushing
 ///
 /// @returns An `LSTracer` instance that's ready to create spans and logs.
 - (instancetype)initWithToken:(NSString *)accessToken


### PR DESCRIPTION
This updates a few docstrings based on Xcode's
CLANG_WARN_DOCUMENTATION_COMMENTS build setting. You can see these
warnings (before this commit) by enabling that in a stable project, or
by doing a `pod install` with CocoaPods 1.2.1, which enables this
setting by default.