### PR TITLE
Fix type annotation

### DIFF
--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -21,7 +21,7 @@ NSString *const LSErrorDomain = @"com.lightstep";
 
 @interface LSTracer ()
 @property(nonatomic, strong) NSMutableArray<NSDictionary *> *pendingJSONSpans;
-@property(nonatomic, strong, readonly) NSDictionary<NSString *, NSString *> *tracerJSON;
+@property(nonatomic, strong, readonly) NSDictionary<NSString *, id> *tracerJSON;
 @property(nonatomic, strong, readonly) LSClockState *clockState;
 
 @property(nonatomic, strong, readonly) dispatch_queue_t flushQueue;


### PR DESCRIPTION
This dictionary was typed to only be strings, but a NSMutableArray was
inserted into it. With Xcode 9 and CP 1.4+ this is a warning by default.