### PR TITLE
Autoreleasepool in `persistSamplesToUserDefaults`

### DIFF
--- a/Pod/Classes/LSClockState.m
+++ b/Pod/Classes/LSClockState.m
@@ -55,9 +55,9 @@ static NSString *kSamplesKey = @"samples";
 static void persistSamplesToUserDefaults(NSArray *samples) {
     @autoreleasepool {
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:@{
-                                                                     kTimestampMicrosKey: @([LSClockState nowMicros]),
-                                                                     kSamplesKey: samples
-                                                                     }];
+            kTimestampMicrosKey: @([LSClockState nowMicros]),
+            kSamplesKey: samples
+        }];
         [[NSUserDefaults standardUserDefaults] setObject:data forKey:kUserDefaultsKey];
     }
 }

--- a/Pod/Classes/LSClockState.m
+++ b/Pod/Classes/LSClockState.m
@@ -53,11 +53,13 @@ static NSString *kSamplesKey = @"samples";
 @end
 
 static void persistSamplesToUserDefaults(NSArray *samples) {
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:@{
-                                                                 kTimestampMicrosKey: @([LSClockState nowMicros]),
-                                                                 kSamplesKey: samples
-                                                                 }];
-    [[NSUserDefaults standardUserDefaults] setObject:data forKey:kUserDefaultsKey];
+    @autoreleasepool {
+        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:@{
+                                                                     kTimestampMicrosKey: @([LSClockState nowMicros]),
+                                                                     kSamplesKey: samples
+                                                                     }];
+        [[NSUserDefaults standardUserDefaults] setObject:data forKey:kUserDefaultsKey];
+    }
 }
 
 @implementation LSClockState


### PR DESCRIPTION
@supermarin has a theory that the autoreleasepool might be being released underneath us while the samples are being persisted, which makes the NSData (from NSKeyedArchiver) get freed by the time we save to NSUserDefaults.

Adding an explicit autorelease pool on top may fix this.