### PR TITLE
Add support for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	cd examples/LightStepTestUI && xcodebuild test \
 	CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
 	-workspace LightStepTestUI.xcworkspace -scheme LightStepTestUI \
-	-destination 'platform=iOS Simulator,name=iPhone 6,OS=10.2'
+	-destination 'platform=iOS Simulator,name=iPhone 6,OS=12.2'
 
 xcode:
 	cd examples/LightStepTestUI && open LightStepTestUI.xcworkspace

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -1,4 +1,9 @@
-#import <UIKit/UIKit.h>
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+    #import <UIKit/UIKit.h>
+#else
+    #import <Cocoa/Cocoa.h>;
+#endif
 #import <opentracing/OTReference.h>
 
 #import "LSClockState.h"

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -60,11 +60,11 @@ NSString *const LSErrorDomain = @"com.lightstep";
         _tracerJSON = @{
             @"guid": [LSUtil hexGUID:_runtimeGuid],
             @"attrs": [LSUtil keyValueArrayFromDictionary:@{
-                @"lightstep.tracer_platform": @"ios",
-                @"lightstep.tracer_platform_version": [[UIDevice currentDevice] systemVersion],
+                @"lightstep.tracer_platform": [LSUtil getTracerPlatform],
+                @"lightstep.tracer_platform_version": [LSUtil getTracerPlatformVersion],
                 @"lightstep.tracer_version": LS_TRACER_VERSION,
                 @"lightstep.component_name": componentName,
-                @"device_model": [[UIDevice currentDevice] model]
+                @"device_model": [LSUtil getDeviceModel]
             }]
         };
 

--- a/Pod/Classes/LSTracer.m
+++ b/Pod/Classes/LSTracer.m
@@ -2,7 +2,7 @@
 #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     #import <UIKit/UIKit.h>
 #else
-    #import <Cocoa/Cocoa.h>;
+    #import <Cocoa/Cocoa.h>
 #endif
 #import <opentracing/OTReference.h>
 
@@ -33,7 +33,9 @@ NSString *const LSErrorDomain = @"com.lightstep";
 @property(nonatomic, strong) dispatch_source_t flushTimer;
 @property(nonatomic, strong) NSDate *lastFlush;
 @property(nonatomic) UInt64 runtimeGuid;
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
 @property(nonatomic) UIBackgroundTaskIdentifier bgTaskId;
+#endif
 @end
 
 #pragma mark - Tracer implementation
@@ -55,7 +57,9 @@ NSString *const LSErrorDomain = @"com.lightstep";
         _enabled = true;
         _clockState = [[LSClockState alloc] init];
         _lastFlush = [NSDate date];
+        #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         _bgTaskId = UIBackgroundTaskInvalid;
+        #endif
         _baseURL = baseURL ?: [NSURL URLWithString:LSDefaultBaseURLString];
         _tracerJSON = @{
             @"guid": [LSUtil hexGUID:_runtimeGuid],
@@ -286,7 +290,7 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
         // Short-circuit.
         return;
     }
-
+    
     // We really want this flush to go through, even if the app enters the
     // background and iOS wants to move on with its life.
     //
@@ -299,6 +303,7 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
     // extant at any given moment, and thus it's safe to store the background
     // task id in _bgTaskId.
     __weak __typeof(self) weakSelf = self;
+    #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     void (^cleanupBlock)(BOOL, NSError *_Nullable) = ^(BOOL endBackgroundTask, NSError *_Nullable error) {
         if (endBackgroundTask) {
             [weakSelf _endBackgroundTask];
@@ -307,6 +312,7 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
             doneCallback(error);
         }
     };
+    #endif
 
     NSMutableDictionary *reqJSON;
     @synchronized(self) {
@@ -327,23 +333,26 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
 
         self.pendingJSONSpans = [NSMutableArray<NSDictionary *> new];
         self.lastFlush = now;
-
-        self.bgTaskId = [[UIApplication sharedApplication]
-            beginBackgroundTaskWithName:@"com.lightstep.flush"
-                      expirationHandler:^{
-                          cleanupBlock(true,
-                                       [NSError errorWithDomain:LSErrorDomain code:LSBackgroundTaskError userInfo:nil]);
-                      }];
-        if (self.bgTaskId == UIBackgroundTaskInvalid) {
-            NSLog(@"unable to enter the background, so skipping flush");
-            cleanupBlock(false, [NSError errorWithDomain:LSErrorDomain code:LSBackgroundTaskError userInfo:nil]);
-            return;
+        #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+            self.bgTaskId = [[UIApplication sharedApplication]
+                beginBackgroundTaskWithName:@"com.lightstep.flush"
+                          expirationHandler:^{
+                              cleanupBlock(true,
+                                           [NSError errorWithDomain:LSErrorDomain code:LSBackgroundTaskError userInfo:nil]);
+                          }];
+            if (self.bgTaskId == UIBackgroundTaskInvalid) {
+                NSLog(@"unable to enter the background, so skipping flush");
+                cleanupBlock(false, [NSError errorWithDomain:LSErrorDomain code:LSBackgroundTaskError userInfo:nil]);
+                return;
         }
+        #endif
     }
 
     NSString *reqBody = [LSUtil objectToJSONString:reqJSON maxLength:LSMaxRequestSize];
     if (reqBody == nil) {
+        #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         cleanupBlock(true, [NSError errorWithDomain:LSErrorDomain code:LSRequestTooLargeError userInfo:nil]);
+#endif
         return;
     }
 
@@ -361,10 +370,12 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
 
             if (error != nil || data == nil) {
+                #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
                 cleanupBlock(true, error);
+#endif
                 return;
             }
-
+            
             __typeof(self) strongSelf = weakSelf;
             SInt64 destinationMicros = [LSClockState nowMicros];
             NSError *jsonError;
@@ -387,8 +398,9 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
                    }
                }
             }
-
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
             cleanupBlock(true, jsonError);
+#endif
         }];
     // "Start" (resume) the HTTP activity.
     [postDataTask resume];
@@ -408,12 +420,14 @@ static NSString *kBasicTracerBaggagePrefix = @"ot-baggage-";
 //
 // Note: do not call directly from outside flush().
 - (void)_endBackgroundTask {
+    #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     @synchronized(self) {
         if (self.bgTaskId != UIBackgroundTaskInvalid) {
             [[UIApplication sharedApplication] endBackgroundTask:self.bgTaskId];
             self.bgTaskId = UIBackgroundTaskInvalid;
         }
     }
+    #endif
 }
 
 @end

--- a/Pod/Classes/LSUtil.h
+++ b/Pod/Classes/LSUtil.h
@@ -12,6 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (UInt64)guidFromHex:(NSString *)hexString;
 + (NSString *)objectToJSONString:(nullable id)obj maxLength:(NSUInteger)maxLength;
 + (NSMutableArray *)keyValueArrayFromDictionary:(NSDictionary<NSString *, NSObject *> *)dict;
++ (NSString *)getTracerPlatform;
++ (NSString *)getTracerPlatformVersion;
++ (NSString *)getDeviceModel;
 
 @end
 

--- a/Pod/Classes/LSUtil.m
+++ b/Pod/Classes/LSUtil.m
@@ -29,6 +29,30 @@
     return json;
 }
 
++ (NSString *)getTracerPlatform {
+    #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+        return @"ios";
+    #else
+        return @"macos":
+    #endif
+}
+
++ (NSString *)getTracerPlatformVersion {
+    #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+        return [[UIDevice currentDevice] systemVersion];
+    #else
+        return [[NSProcessInfo processInfo] operatingSystemVersionString];
+    #endif
+}
+
++ (NSString *)getDeviceModel {
+    #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+        return [[UIDevice currentDevice] model];
+    #else
+        return @"Macintosh";
+    #endif
+}
+
 #pragma mark - Private
 
 // Convert the object to JSON without string length constraints

--- a/Pod/Classes/LSUtil.m
+++ b/Pod/Classes/LSUtil.m
@@ -33,7 +33,7 @@
     #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         return @"ios";
     #else
-        return @"macos":
+        return @"macos";
     #endif
 }
 

--- a/PodInstallTarget/PodInstallTarget.xcodeproj/project.pbxproj
+++ b/PodInstallTarget/PodInstallTarget.xcodeproj/project.pbxproj
@@ -114,7 +114,6 @@
 				A9C454A91D80969F000283E1 /* Sources */,
 				A9C454AA1D80969F000283E1 /* Frameworks */,
 				A9C454AB1D80969F000283E1 /* Resources */,
-				C6FC17C77F76119F2B2BA5A5 /* [CP] Embed Pods Frameworks */,
 				D2D67DF1DEA339BB16721027 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -178,28 +177,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PodInstallTarget-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		C6FC17C77F76119F2B2BA5A5 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PodInstallTarget/Pods-PodInstallTarget-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D2D67DF1DEA339BB16721027 /* [CP] Copy Pods Resources */ = {
@@ -208,13 +195,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PodInstallTarget/Pods-PodInstallTarget-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC/gRPCCertificates.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PodInstallTarget/Pods-PodInstallTarget-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PodInstallTarget/Pods-PodInstallTarget-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/PodInstallTarget/PodInstallTarget.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PodInstallTarget/PodInstallTarget.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/AppDelegate.h
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/AppDelegate.h
@@ -1,0 +1,15 @@
+//
+//  AppDelegate.h
+//  LightStepCocoaTestUI
+//
+//  Created by Austin Parker on 7/15/19.
+//  Copyright © 2019 LightStep. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+
+@end
+

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/AppDelegate.m
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/AppDelegate.m
@@ -1,0 +1,33 @@
+//
+//  AppDelegate.m
+//  LightStepCocoaTestUI
+//
+//  Created by Austin Parker on 7/15/19.
+//  Copyright © 2019 LightStep. All rights reserved.
+//
+
+#import "AppDelegate.h"
+#import "lightstep/LSTracer.h"
+#import "opentracing/OTGlobal.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+    // Insert code here to initialize your application
+    LSTracer* tracer = [[LSTracer alloc] initWithToken:@"TEST_TOKEN" componentName:@"LightStepCocoaTestUI" flushIntervalSeconds:2];
+    tracer.maxSpanRecords = 600;
+    
+    [OTGlobal initSharedTracer:tracer];
+}
+
+
+- (void)applicationWillTerminate:(NSNotification *)aNotification {
+    // Insert code here to tear down your application
+}
+
+
+@end

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/Assets.xcassets/Contents.json
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/Base.lproj/Main.storyboard
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/Base.lproj/Main.storyboard
@@ -1,0 +1,765 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="LightStepCocoaTestUI" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="LightStepCocoaTestUI" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About LightStepCocoaTestUI" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide LightStepCocoaTestUI" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit LightStepCocoaTestUI" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq">
+                                                        <connections>
+                                                            <action selector="orderFrontFontPanel:" target="YLy-65-1bz" id="WHr-nq-2xA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="hqk-hr-sYV"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq">
+                                                        <connections>
+                                                            <action selector="addFontTrait:" target="YLy-65-1bz" id="IHV-OB-c03"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="Uc7-di-UnL"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST">
+                                                        <connections>
+                                                            <action selector="modifyFont:" target="YLy-65-1bz" id="HcX-Lf-eNd"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="LightStepCocoaTestUI Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate"/>
+                <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                        <connections>
+                            <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZSX-5e-ylF">
+                                <rect key="frame" x="184" y="222" width="112" height="17"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="LightStep Sample" id="gj8-tf-lJg">
+                                    <font key="font" usesAppearanceFont="YES"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UmG-aN-aUS">
+                                <rect key="frame" x="192" y="176" width="96" height="22"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Rzw-mU-kLS">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <action selector="textField:" target="XfG-lQ-9wD" id="cD6-br-iON"/>
+                                </connections>
+                            </textField>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jfG-jj-XdC">
+                                <rect key="frame" x="199" y="124" width="83" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Search" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xba-Wa-FxO">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="buttonWasClicked:" target="XfG-lQ-9wD" id="7qd-VT-hPN"/>
+                                </connections>
+                            </button>
+                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Dx-Ag-PsL">
+                                <rect key="frame" x="9" y="9" width="463" height="114"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" selectable="YES" title="Results" id="mZL-qS-ueJ">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                    </view>
+                    <connections>
+                        <outlet property="resultsTextView" destination="1Dx-Ag-PsL" id="7Hp-lw-Miu"/>
+                        <outlet property="userNameField" destination="UmG-aN-aUS" id="b1Y-7l-ddp"/>
+                    </connections>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="655"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/Info.plist
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2019 LightStep. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/LightStepCocoaTestUI.entitlements
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/LightStepCocoaTestUI.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/ViewController.h
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/ViewController.h
@@ -1,0 +1,17 @@
+//
+//  ViewController.h
+//  LightStepCocoaTestUI
+//
+//  Created by Austin Parker on 7/15/19.
+//  Copyright © 2019 LightStep. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface ViewController : NSViewController
+
+@property (weak) IBOutlet NSTextField *resultsTextView;
+@property (weak) IBOutlet NSTextField *userNameField;
+
+@end
+

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/ViewController.m
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/ViewController.m
@@ -1,0 +1,228 @@
+//
+//  ViewController.m
+//  LightStepCocoaTestUI
+//
+//  Created by Austin Parker on 7/15/19.
+//  Copyright © 2019 LightStep. All rights reserved.
+//
+
+#import "ViewController.h"
+#import "lightstep/LSTracer.h"
+#import "opentracing/OTGlobal.h"
+
+@interface UserInfo : NSObject {
+    void (^_completionHandler)(NSString* text);
+}
+@property (strong, atomic) NSString* login;
+@property (strong, atomic) NSString* type;
+@property (strong, atomic) NSMutableArray* repoNames;
+@property (atomic) NSUInteger eventTotal;
+@property (strong, atomic) NSMutableDictionary* eventCount;
+
+@property (atomic) NSInteger callbacksRemaining;
+@end
+
+@implementation UserInfo
+
+/**
+ * Standard init method.
+ */
+- (id)init {
+    if (self = [super init]) {
+        self.repoNames = [NSMutableArray new];
+        self.eventCount = [NSMutableDictionary new];
+    }
+    return self;
+}
+
+/**
+ * Given a username, makes multiples asynchronous queries to GitHub, collects
+ * info about the user in this object, and finally calls the completion handler
+ * when all queries are done.
+ *
+ * NOTE: this method is only safe to call once per UserInfo object in order to
+ * keep the code simple.
+ */
+- (void)queryInfo:(NSString*)username
+       parentSpan:(id<OTSpan>)parentSpan
+completionHandler:(void(^)(NSString*))completionHandler {
+    
+    NSString* url = [NSString stringWithFormat:@"https://api.github.com/users/%@", username];
+    
+    self.callbacksRemaining = 3;
+    self->_completionHandler = completionHandler;
+    
+    // Set a timeout.  The code currently intentionally does not handle the case
+    // missing usernames correctly and the timeout here will be hit; this is
+    // useful for demonstrating an error trace.
+    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC * 8.0);
+    dispatch_after(delay, dispatch_get_main_queue(), ^(void){
+        if (self.callbacksRemaining > 0) {
+            NSError* err = [NSError errorWithDomain:@"com.lightstep.example"
+                                               code:408
+                                           userInfo:@{NSLocalizedDescriptionKey:@"Something went wrong!"}];
+            [self _queryInfoStep:err];
+        }
+    });
+    
+    [self _getHTTP:parentSpan url:url completionHandler:^(id resp, NSError* error) {
+        self.login = resp[@"login"];
+        self.type  = resp[@"type"];
+        [self _queryInfoStep:error];
+        
+        [self _getHTTP:parentSpan url:resp[@"repos_url"] completionHandler:^(id repoList, NSError* error) {
+            for (NSDictionary* repo in repoList) {
+                [self.repoNames addObject:repo[@"name"]];
+            }
+            [self _queryInfoStep:error];
+        }];
+        
+        [self _getHTTP:parentSpan url:resp[@"received_events_url"] completionHandler:^(id eventList, NSError* error) {
+            for (NSDictionary* event in eventList) {
+                NSString* key = event[@"type"];
+                NSNumber* count = [self.eventCount objectForKey:key] ?: @0;
+                [self.eventCount setObject:@([count intValue] + 1) forKey:key];
+                self.eventTotal++;
+            }
+            [self _queryInfoStep:error];
+        }];
+    }];
+}
+
+/**
+ * Called at the completion of each asynchronous API call. Calls the
+ * completion callback on the first error or calls the completion callback with
+ * the full user info onces it is available.
+ */
+- (void)_queryInfoStep:(NSError*)error {
+    NSString* text;
+    if (error != nil) {
+        self.callbacksRemaining -= MAX(self.callbacksRemaining, 1);
+        text = error.localizedDescription;
+    } else {
+        self.callbacksRemaining--;
+        text = [self _infoString];
+    }
+    
+    if (self.callbacksRemaining == 0) {
+        (self->_completionHandler)(text);
+    }
+}
+
+/**
+ * Calls the callback with either an NSArray* or NSDictionary* depending on the
+ * JSON returned by the URL.
+ */
+- (void)_getHTTP:(id<OTSpan>)parentSpan
+             url:(NSString*)urlString
+completionHandler:(void (^)(id response, NSError *error))completionHandler {
+    
+    // Rewrite the URL to use the LightStep proxy server
+    NSString* gitHubPrefix = @"https://api.github.com/";
+    NSString* urlPath = [urlString substringFromIndex:([gitHubPrefix length] - 1)];
+    
+    id<OTSpan> span = [[OTGlobal sharedTracer] startSpan:@"NSURLRequest" childOf:parentSpan.context];
+    
+    NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    NSMutableDictionary* headers = [NSMutableDictionary dictionaryWithDictionary:[config HTTPAdditionalHeaders]];
+    [headers setObject:@"LightStep iOS Example" forKey:@"User-Agent"];
+    [headers setObject:((LSTracer*)span.tracer).accessToken forKey:@"LightStep-Access-Token"];
+    [[OTGlobal sharedTracer] inject:span.context format:OTFormatTextMap carrier:headers];
+    config.HTTPAdditionalHeaders = headers;
+    
+    NSURLComponents* urlComponents = [NSURLComponents new];
+    urlComponents.scheme = @"http";
+    urlComponents.host = @"example-proxy.lightstep.com";
+    urlComponents.port = @(80);
+    urlComponents.path = urlPath;
+    NSURL* url = [urlComponents URL];
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url
+                                                           cachePolicy:NSURLRequestReloadIgnoringLocalAndRemoteCacheData
+                                                       timeoutInterval:10];
+    [request setHTTPMethod:@"GET"];
+    
+    NSURLSession* session = [NSURLSession sessionWithConfiguration:config];
+    NSURLSessionDataTask* task =
+    [session dataTaskWithRequest:request
+               completionHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
+                   id obj = nil;
+                   if (error == nil) {
+                       
+                       obj = [NSJSONSerialization JSONObjectWithData:data
+                                                             options:NSJSONReadingMutableContainers
+                                                               error:nil];
+                       [span logEvent:@"response" payload:obj];
+                   } else {
+                       [span logEvent:@"error" payload:error.localizedDescription];
+                   }
+                   
+                   @try {
+                       completionHandler(obj, error);
+                   } @catch(NSException* exception) {
+                       [span log:@"Exception in completion handler" timestamp:nil payload:exception];
+                   }
+                   [span finish];
+               }];
+    [task resume];
+}
+
+/**
+ * Convert the colleted UserInfo to an NSString.
+ */
+- (NSString*)_infoString {
+    NSMutableString* output = [NSMutableString new];
+    [output appendString:[NSString stringWithFormat:@"User: %@\n", self.login]];
+    [output appendString:[NSString stringWithFormat:@"Type: %@\n", self.type]];
+    
+    [output appendString:[NSString stringWithFormat:@"Public repositories: %@\n", @(self.repoNames.count)]];
+    for (NSString* name in self.repoNames) {
+        [output appendString:[NSString stringWithFormat:@"\t%@\n", name]];
+    }
+    [output appendString:[NSString stringWithFormat:@"Recent events: %@\n", @(self.eventTotal)]];
+    for (NSString* key in self.eventCount) {
+        [output appendString:[NSString stringWithFormat:@"\t%@: %@\n", key, self.eventCount[key]]];
+    }
+    return output;
+}
+
+
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Do any additional setup after loading the view.
+}
+
+
+- (void)setRepresentedObject:(id)representedObject {
+    [super setRepresentedObject:representedObject];
+
+    // Update the view, if already loaded.
+}
+
+- (IBAction)buttonWasClicked:(NSButton *)sender {
+    id<OTSpan> span = [[OTGlobal sharedTracer] startSpan:@"button pressed"];
+    
+    self.resultsTextView.stringValue = @"Starting query...";
+    [[UserInfo new] queryInfo:self.userNameField.stringValue
+                   parentSpan:span
+            completionHandler:^(NSString* text) {
+                [span logEvent:@"query_complete"
+                       payload:@{@"main_thread":@([NSThread isMainThread])}];
+                NSString* displayString = [NSString stringWithFormat:@"%@\n\nView tracer at:\n %@\n", text, [(LSSpan*)span traceURL]];
+                
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [span logEvent:@"ui_update"
+                           payload:@{@"main_thread":@([NSThread isMainThread])}];
+                    self.resultsTextView.stringValue = displayString;
+                    [span finish];
+                });
+            }];
+}
+
+
+@end

--- a/examples/LightStepTestUI/LightStepCocoaTestUI/main.m
+++ b/examples/LightStepTestUI/LightStepCocoaTestUI/main.m
@@ -1,0 +1,13 @@
+//
+//  main.m
+//  LightStepCocoaTestUI
+//
+//  Created by Austin Parker on 7/15/19.
+//  Copyright © 2019 LightStep. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char * argv[]) {
+    return NSApplicationMain(argc, argv);
+}

--- a/examples/LightStepTestUI/LightStepTestUI.xcodeproj/project.pbxproj
+++ b/examples/LightStepTestUI/LightStepTestUI.xcodeproj/project.pbxproj
@@ -156,8 +156,6 @@
 				811B5EBF1C7E80F90076110E /* Sources */,
 				811B5EC01C7E80F90076110E /* Frameworks */,
 				811B5EC11C7E80F90076110E /* Resources */,
-				DA0B47114BE1B334EB0974F1 /* [CP] Embed Pods Frameworks */,
-				B945AACE850172993BD52592 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -176,8 +174,6 @@
 				817C86171C84D0200060C5FD /* Sources */,
 				817C86181C84D0200060C5FD /* Frameworks */,
 				817C86191C84D0200060C5FD /* Resources */,
-				60FDA512AA08A24637F11249 /* [CP] Embed Pods Frameworks */,
-				8B445DCFFA094F3887C111CC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -264,66 +260,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		60FDA512AA08A24637F11249 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LightStepUnitTests/Pods-LightStepUnitTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8B445DCFFA094F3887C111CC /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LightStepUnitTests/Pods-LightStepUnitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B945AACE850172993BD52592 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LightStepTestUI/Pods-LightStepTestUI-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DA0B47114BE1B334EB0974F1 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LightStepTestUI/Pods-LightStepTestUI-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E063C043E467349F2E6AAE64 /* [CP] Check Pods Manifest.lock */ = {

--- a/examples/LightStepTestUI/LightStepTestUI.xcodeproj/project.pbxproj
+++ b/examples/LightStepTestUI/LightStepTestUI.xcodeproj/project.pbxproj
@@ -15,6 +15,12 @@
 		811B5ED31C7E80F90076110E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 811B5ED21C7E80F90076110E /* Assets.xcassets */; };
 		811B5ED61C7E80F90076110E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 811B5ED41C7E80F90076110E /* LaunchScreen.storyboard */; };
 		817C861E1C84D0200060C5FD /* LightStepUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 817C861D1C84D0200060C5FD /* LightStepUnitTests.m */; };
+		D2232F6022DCB13E00D5E081 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D2232F5F22DCB13E00D5E081 /* AppDelegate.m */; };
+		D2232F6322DCB13E00D5E081 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D2232F6222DCB13E00D5E081 /* ViewController.m */; };
+		D2232F6522DCB13F00D5E081 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D2232F6422DCB13F00D5E081 /* Assets.xcassets */; };
+		D2232F6822DCB13F00D5E081 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2232F6622DCB13F00D5E081 /* Main.storyboard */; };
+		D2232F6B22DCB13F00D5E081 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D2232F6A22DCB13F00D5E081 /* main.m */; };
+		D855D7A113EEE724FDDAAC27 /* libPods-LightStepCocoaTestUI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 53F3B9097129B21CF60F26D2 /* libPods-LightStepCocoaTestUI.a */; };
 		FC8CEA6067CDE25B50423D3D /* libPods-LightStepUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B65B1CD6D54ADBD1AA2719A7 /* libPods-LightStepUnitTests.a */; };
 /* End PBXBuildFile section */
 
@@ -31,6 +37,8 @@
 /* Begin PBXFileReference section */
 		07C33A36D9780B67E071DDE8 /* Pods-LightStepTestUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LightStepTestUI.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LightStepTestUI/Pods-LightStepTestUI.debug.xcconfig"; sourceTree = "<group>"; };
 		4E3F58243825167ED6188095 /* Pods-LightStepTestUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LightStepTestUI.release.xcconfig"; path = "Pods/Target Support Files/Pods-LightStepTestUI/Pods-LightStepTestUI.release.xcconfig"; sourceTree = "<group>"; };
+		53F3B9097129B21CF60F26D2 /* libPods-LightStepCocoaTestUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LightStepCocoaTestUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		55FFEFC57FDB48E55CD92868 /* Pods-LightStepCocoaTestUI.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LightStepCocoaTestUI.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LightStepCocoaTestUI/Pods-LightStepCocoaTestUI.debug.xcconfig"; sourceTree = "<group>"; };
 		59B7015A1F97CC51513E4FA0 /* libPods-LightStepTestUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LightStepTestUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		811B5EC31C7E80F90076110E /* LightStepTestUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LightStepTestUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		811B5EC71C7E80F90076110E /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -45,10 +53,22 @@
 		817C861B1C84D0200060C5FD /* LightStepUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LightStepUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		817C861D1C84D0200060C5FD /* LightStepUnitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LightStepUnitTests.m; sourceTree = "<group>"; };
 		817C861F1C84D0200060C5FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		90C924A50B9E013C1DB4DD08 /* Pods-LightStepCocoaTestUI.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LightStepCocoaTestUI.release.xcconfig"; path = "Pods/Target Support Files/Pods-LightStepCocoaTestUI/Pods-LightStepCocoaTestUI.release.xcconfig"; sourceTree = "<group>"; };
 		A9C454551D7F4369000283E1 /* lightstep.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = lightstep.framework; path = "../../../../Library/Developer/Xcode/DerivedData/LightStepTestUI-gygbfnxbvlvkuzgefierexnqwaxx/Build/Products/Debug-iphonesimulator/lightstep/lightstep.framework"; sourceTree = "<group>"; };
 		B65B1CD6D54ADBD1AA2719A7 /* libPods-LightStepUnitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LightStepUnitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C44D7FC31F0A312669727212 /* Pods-LightStepUnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LightStepUnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-LightStepUnitTests/Pods-LightStepUnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		C9D5B00D38FF88B3D56EB4BA /* Pods-LightStepUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LightStepUnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LightStepUnitTests/Pods-LightStepUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D2232F5C22DCB13E00D5E081 /* LightStepCocoaTestUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LightStepCocoaTestUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2232F5E22DCB13E00D5E081 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		D2232F5F22DCB13E00D5E081 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		D2232F6122DCB13E00D5E081 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		D2232F6222DCB13E00D5E081 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		D2232F6422DCB13F00D5E081 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D2232F6722DCB13F00D5E081 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		D2232F6922DCB13F00D5E081 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D2232F6A22DCB13F00D5E081 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		D2232F6C22DCB13F00D5E081 /* LightStepCocoaTestUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LightStepCocoaTestUI.entitlements; sourceTree = "<group>"; };
+		D2C1C98F229F22C500C18821 /* libTracer.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libTracer.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +88,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D2232F5922DCB13E00D5E081 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D855D7A113EEE724FDDAAC27 /* libPods-LightStepCocoaTestUI.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2C1C98D229F22C500C18821 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -77,6 +112,7 @@
 				A9C454551D7F4369000283E1 /* lightstep.framework */,
 				59B7015A1F97CC51513E4FA0 /* libPods-LightStepTestUI.a */,
 				B65B1CD6D54ADBD1AA2719A7 /* libPods-LightStepUnitTests.a */,
+				53F3B9097129B21CF60F26D2 /* libPods-LightStepCocoaTestUI.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -86,6 +122,7 @@
 			children = (
 				811B5EC51C7E80F90076110E /* LightStepTestUI */,
 				817C861C1C84D0200060C5FD /* LightStepUnitTests */,
+				D2232F5D22DCB13E00D5E081 /* LightStepCocoaTestUI */,
 				811B5EC41C7E80F90076110E /* Products */,
 				F5ED9A4DDD106094BF7E51DD /* Pods */,
 				14619A5966212857C456D1BA /* Frameworks */,
@@ -97,6 +134,8 @@
 			children = (
 				811B5EC31C7E80F90076110E /* LightStepTestUI.app */,
 				817C861B1C84D0200060C5FD /* LightStepUnitTests.xctest */,
+				D2C1C98F229F22C500C18821 /* libTracer.dylib */,
+				D2232F5C22DCB13E00D5E081 /* LightStepCocoaTestUI.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -134,6 +173,22 @@
 			path = LightStepUnitTests;
 			sourceTree = "<group>";
 		};
+		D2232F5D22DCB13E00D5E081 /* LightStepCocoaTestUI */ = {
+			isa = PBXGroup;
+			children = (
+				D2232F5E22DCB13E00D5E081 /* AppDelegate.h */,
+				D2232F5F22DCB13E00D5E081 /* AppDelegate.m */,
+				D2232F6122DCB13E00D5E081 /* ViewController.h */,
+				D2232F6222DCB13E00D5E081 /* ViewController.m */,
+				D2232F6422DCB13F00D5E081 /* Assets.xcassets */,
+				D2232F6622DCB13F00D5E081 /* Main.storyboard */,
+				D2232F6922DCB13F00D5E081 /* Info.plist */,
+				D2232F6A22DCB13F00D5E081 /* main.m */,
+				D2232F6C22DCB13F00D5E081 /* LightStepCocoaTestUI.entitlements */,
+			);
+			path = LightStepCocoaTestUI;
+			sourceTree = "<group>";
+		};
 		F5ED9A4DDD106094BF7E51DD /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -141,11 +196,23 @@
 				4E3F58243825167ED6188095 /* Pods-LightStepTestUI.release.xcconfig */,
 				C9D5B00D38FF88B3D56EB4BA /* Pods-LightStepUnitTests.debug.xcconfig */,
 				C44D7FC31F0A312669727212 /* Pods-LightStepUnitTests.release.xcconfig */,
+				55FFEFC57FDB48E55CD92868 /* Pods-LightStepCocoaTestUI.debug.xcconfig */,
+				90C924A50B9E013C1DB4DD08 /* Pods-LightStepCocoaTestUI.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D2C1C98B229F22C500C18821 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		811B5EC21C7E80F90076110E /* LightStepTestUI */ = {
@@ -185,6 +252,41 @@
 			productReference = 817C861B1C84D0200060C5FD /* LightStepUnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D2232F5B22DCB13E00D5E081 /* LightStepCocoaTestUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D2232F6F22DCB13F00D5E081 /* Build configuration list for PBXNativeTarget "LightStepCocoaTestUI" */;
+			buildPhases = (
+				8BE9BE5AF20E1AEAF293C6F5 /* [CP] Check Pods Manifest.lock */,
+				D2232F5822DCB13E00D5E081 /* Sources */,
+				D2232F5922DCB13E00D5E081 /* Frameworks */,
+				D2232F5A22DCB13E00D5E081 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LightStepCocoaTestUI;
+			productName = LightStepCocoaTestUI;
+			productReference = D2232F5C22DCB13E00D5E081 /* LightStepCocoaTestUI.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D2C1C98E229F22C500C18821 /* Tracer */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D2C1C997229F22C500C18821 /* Build configuration list for PBXNativeTarget "Tracer" */;
+			buildPhases = (
+				D2C1C98B229F22C500C18821 /* Headers */,
+				D2C1C98C229F22C500C18821 /* Sources */,
+				D2C1C98D229F22C500C18821 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Tracer;
+			productName = Tracer;
+			productReference = D2C1C98F229F22C500C18821 /* libTracer.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -196,11 +298,21 @@
 				TargetAttributes = {
 					811B5EC21C7E80F90076110E = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = 5F7HL6C44K;
+						DevelopmentTeam = A45Q5DN8BF;
+						ProvisioningStyle = Manual;
 					};
 					817C861A1C84D0200060C5FD = {
 						CreatedOnToolsVersion = 7.2.1;
+						ProvisioningStyle = Manual;
 						TestTargetID = 811B5EC21C7E80F90076110E;
+					};
+					D2232F5B22DCB13E00D5E081 = {
+						CreatedOnToolsVersion = 10.2.1;
+						ProvisioningStyle = Manual;
+					};
+					D2C1C98E229F22C500C18821 = {
+						CreatedOnToolsVersion = 10.2.1;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -209,6 +321,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -219,6 +332,8 @@
 			targets = (
 				811B5EC21C7E80F90076110E /* LightStepTestUI */,
 				817C861A1C84D0200060C5FD /* LightStepUnitTests */,
+				D2C1C98E229F22C500C18821 /* Tracer */,
+				D2232F5B22DCB13E00D5E081 /* LightStepCocoaTestUI */,
 			);
 		};
 /* End PBXProject section */
@@ -241,6 +356,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D2232F5A22DCB13E00D5E081 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2232F6522DCB13F00D5E081 /* Assets.xcassets in Resources */,
+				D2232F6822DCB13F00D5E081 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -256,6 +380,28 @@
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-LightStepUnitTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8BE9BE5AF20E1AEAF293C6F5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-LightStepCocoaTestUI-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -301,6 +447,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D2232F5822DCB13E00D5E081 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2232F6322DCB13E00D5E081 /* ViewController.m in Sources */,
+				D2232F6B22DCB13F00D5E081 /* main.m in Sources */,
+				D2232F6022DCB13E00D5E081 /* AppDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2C1C98C229F22C500C18821 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -328,6 +491,14 @@
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
+		D2232F6622DCB13F00D5E081 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D2232F6722DCB13F00D5E081 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
@@ -350,6 +521,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -399,6 +571,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -429,7 +602,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
-				DEVELOPMENT_TEAM = 5F7HL6C44K;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = A45Q5DN8BF;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"COCOAPODS=1",
@@ -442,6 +617,7 @@
 				PODS_ROOT = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lightstep.LightStepTestUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -451,7 +627,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
-				DEVELOPMENT_TEAM = 5F7HL6C44K;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = A45Q5DN8BF;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"COCOAPODS=1",
@@ -464,6 +642,7 @@
 				PODS_ROOT = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lightstep.LightStepTestUI;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
@@ -472,11 +651,15 @@
 			baseConfigurationReference = C9D5B00D38FF88B3D56EB4BA /* Pods-LightStepUnitTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LightStepUnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lightstep.LightStepUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LightStepTestUI.app/LightStepTestUI";
 			};
 			name = Debug;
@@ -486,12 +669,164 @@
 			baseConfigurationReference = C44D7FC31F0A312669727212 /* Pods-LightStepUnitTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = LightStepUnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lightstep.LightStepUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LightStepTestUI.app/LightStepTestUI";
+			};
+			name = Release;
+		};
+		D2232F6D22DCB13F00D5E081 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 55FFEFC57FDB48E55CD92868 /* Pods-LightStepCocoaTestUI.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LightStepCocoaTestUI/LightStepCocoaTestUI.entitlements;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = LightStepCocoaTestUI/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = LightStep.LightStepCocoaTestUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		D2232F6E22DCB13F00D5E081 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 90C924A50B9E013C1DB4DD08 /* Pods-LightStepCocoaTestUI.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = LightStepCocoaTestUI/LightStepCocoaTestUI.entitlements;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = LightStepCocoaTestUI/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = LightStep.LightStepCocoaTestUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		D2C1C995229F22C500C18821 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D2C1C996229F22C500C18821 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -521,6 +856,24 @@
 			buildConfigurations = (
 				817C86221C84D0200060C5FD /* Debug */,
 				817C86231C84D0200060C5FD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2232F6F22DCB13F00D5E081 /* Build configuration list for PBXNativeTarget "LightStepCocoaTestUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2232F6D22DCB13F00D5E081 /* Debug */,
+				D2232F6E22DCB13F00D5E081 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2C1C997229F22C500C18821 /* Build configuration list for PBXNativeTarget "Tracer" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2C1C995229F22C500C18821 /* Debug */,
+				D2C1C996229F22C500C18821 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/examples/LightStepTestUI/LightStepTestUI.xcodeproj/xcshareddata/xcschemes/LightStepTestUI.xcscheme
+++ b/examples/LightStepTestUI/LightStepTestUI.xcodeproj/xcshareddata/xcschemes/LightStepTestUI.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "811B5EC21C7E80F90076110E"
+               BuildableName = "LightStepTestUI.app"
+               BlueprintName = "LightStepTestUI"
+               ReferencedContainer = "container:LightStepTestUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "817C861A1C84D0200060C5FD"
+               BuildableName = "LightStepUnitTests.xctest"
+               BlueprintName = "LightStepUnitTests"
+               ReferencedContainer = "container:LightStepTestUI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "811B5EC21C7E80F90076110E"
+            BuildableName = "LightStepTestUI.app"
+            BlueprintName = "LightStepTestUI"
+            ReferencedContainer = "container:LightStepTestUI.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "811B5EC21C7E80F90076110E"
+            BuildableName = "LightStepTestUI.app"
+            BlueprintName = "LightStepTestUI"
+            ReferencedContainer = "container:LightStepTestUI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "811B5EC21C7E80F90076110E"
+            BuildableName = "LightStepTestUI.app"
+            BlueprintName = "LightStepTestUI"
+            ReferencedContainer = "container:LightStepTestUI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/LightStepTestUI/LightStepTestUI.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/LightStepTestUI/LightStepTestUI.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/LightStepTestUI/LightStepTestUI/AppDelegate.m
+++ b/examples/LightStepTestUI/LightStepTestUI/AppDelegate.m
@@ -14,7 +14,7 @@
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    LSTracer* tracer = [[LSTracer alloc] initWithToken:@"DEVELOPMENT_TOKEN_bhs" componentName:@"LightStepTestUI" flushIntervalSeconds:2];
+    LSTracer* tracer = [[LSTracer alloc] initWithToken:@"TEST_TOKEN" componentName:@"LightStepTestUI" flushIntervalSeconds:2];
     tracer.maxSpanRecords = 600;
 
     [OTGlobal initSharedTracer:tracer];

--- a/examples/LightStepTestUI/LightStepTestUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/LightStepTestUI/LightStepTestUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/examples/LightStepTestUI/LightStepTestUI/Base.lproj/Main.storyboard
+++ b/examples/LightStepTestUI/LightStepTestUI/Base.lproj/Main.storyboard
@@ -1,9 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="14F1605" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,7 +18,7 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="LightStep Example" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HTe-bz-IBB">
@@ -44,13 +47,13 @@
                             </button>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" misplaced="YES" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="LY1-zL-2UB">
                                 <rect key="frame" x="20" y="173" width="560" height="354"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <dataDetectorType key="dataDetectorTypes" link="YES"/>
                             </textView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="LY1-zL-2UB" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="0zm-mM-5lS"/>
                             <constraint firstItem="Hcv-Ih-BNt" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="3oB-4o-8aa"/>

--- a/examples/LightStepTestUI/LightStepUnitTests/LightStepUnitTests.m
+++ b/examples/LightStepTestUI/LightStepUnitTests/LightStepUnitTests.m
@@ -39,12 +39,12 @@ const NSUInteger kMaxLength = 8192;
     // Integer
     XCTAssertEqualObjects([LSUtil objectToJSONString:@42 maxLength:kMaxLength], @"42");
     // Float
-    XCTAssertEqualObjects([LSUtil objectToJSONString:@3.14 maxLength:kMaxLength], @"3.14");
+    XCTAssertEqualObjects([LSUtil objectToJSONString:@3.14 maxLength:kMaxLength], @"3.1400000000000001");
     // Empty array
     XCTAssertEqualObjects([LSUtil objectToJSONString:@[] maxLength:kMaxLength], @"[]");
     // Regular array
     NSArray *arr = @[@"test", @42, @3.14];
-    XCTAssertEqualObjects([LSUtil objectToJSONString:arr maxLength:kMaxLength], @"[\"test\",42,3.14]");
+    XCTAssertEqualObjects([LSUtil objectToJSONString:arr maxLength:kMaxLength], @"[\"test\",42,3.1400000000000001]");
     // Empty dictionary
     XCTAssertEqualObjects([LSUtil objectToJSONString:@{} maxLength:kMaxLength], @"{}");
     // Simple dictionary
@@ -52,7 +52,7 @@ const NSUInteger kMaxLength = 8192;
     // guarentees for dictionaries.
     NSDictionary *dict = @{ @"string": @"test", @"integer": @42, @"float": @3.14 };
     XCTAssertEqualObjects([LSUtil objectToJSONString:dict maxLength:kMaxLength],
-                          @"{\"string\":\"test\",\"integer\":42,\"float\":3.14}");
+                          @"{\"string\":\"test\",\"integer\":42,\"float\":3.1400000000000001}");
 }
 
 - (void)testObjectToJSONStringItsComplicated {

--- a/examples/LightStepTestUI/Podfile
+++ b/examples/LightStepTestUI/Podfile
@@ -4,16 +4,22 @@
 # use_frameworks!
 #
 source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
 
 install! 'cocoapods', :deterministic_uuids => false
 
 workspace 'LightStepTestUI'
 
 target 'LightStepTestUI' do
+  platform :ios, '8.0'
+  pod 'lightstep', :path => '../..'
+end
+
+target 'LightStepCocoaTestUI' do
+  platform :macos, '10.11'
   pod 'lightstep', :path => '../..'
 end
 
 target 'LightStepUnitTests' do
+  platform :ios, '8.0'
   pod 'lightstep', :path => '../..'
 end

--- a/examples/LightStepTestUI/Podfile.lock
+++ b/examples/LightStepTestUI/Podfile.lock
@@ -1,19 +1,23 @@
 PODS:
   - lightstep (3.2.11):
-    - opentracing (~> 0.4.0)
-  - opentracing (0.4.2)
+    - opentracing (~> 0.5.1)
+  - opentracing (0.5.1)
 
 DEPENDENCIES:
   - lightstep (from `../..`)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - opentracing
+
 EXTERNAL SOURCES:
   lightstep:
-    :path: ../..
+    :path: "../.."
 
 SPEC CHECKSUMS:
-  lightstep: abf0705906ece8e8eebecc53943d1cf3f03abed3
-  opentracing: ead1caa5478ee78318bda55862fe33a2e67478a4
+  lightstep: 9b99175dbdb19e3e5632ec5a2e8ed201c22ac319
+  opentracing: f21afebfecbcc50a3fd367a6b30331f0bd094e29
 
 PODFILE CHECKSUM: ab77b8c59bf40240bec48ed4c7abaa4e04891fcc
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.7.0

--- a/examples/LightStepTestUI/Podfile.lock
+++ b/examples/LightStepTestUI/Podfile.lock
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  lightstep: 9b99175dbdb19e3e5632ec5a2e8ed201c22ac319
+  lightstep: 1ec07c92b285035f53c8c34d2f1f403346e69ad5
   opentracing: f21afebfecbcc50a3fd367a6b30331f0bd094e29
 
-PODFILE CHECKSUM: ab77b8c59bf40240bec48ed4c7abaa4e04891fcc
+PODFILE CHECKSUM: 215ca43be292ffbbbedccfc477a98ae1f33fbb65
 
 COCOAPODS: 1.7.0

--- a/lightstep.podspec
+++ b/lightstep.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = { "LightStep" => "support@lightstep.com" }
   s.source           = { :git => "https://github.com/lightstep/lightstep-tracer-objc.git", :tag => s.version.to_s }
 
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '9.0'
 

--- a/lightstep.podspec
+++ b/lightstep.podspec
@@ -12,10 +12,14 @@ Pod::Spec.new do |s|
   s.author           = { "LightStep" => "support@lightstep.com" }
   s.source           = { :git => "https://github.com/lightstep/lightstep-tracer-objc.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '7.0'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.11'
+  s.tvos.deployment_target = '9.0'
 
   s.source_files = 'Pod/Classes/*'
+  s.osx.framework = 'AppKit'
+  
   s.requires_arc = true
-  s.dependency 'opentracing', '~>0.4.0'
+  s.dependency 'opentracing', '~>0.5.1'
 
 end

--- a/lightstep.podspec.src
+++ b/lightstep.podspec.src
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = { "LightStep" => "support@lightstep.com" }
   s.source           = { :git => "https://github.com/lightstep/lightstep-tracer-objc.git", :tag => s.version.to_s }
 
-  s.platforms        = { :ios => '7.0', :watchos => '2', :osx => '10.9', :tvos => '9.0 }
+  s.platforms        = { :ios => '7.0', :osx => '10.11', :tvos => '9.0' }
 
   s.source_files = 'Pod/Classes/*'
   s.requires_arc = true

--- a/lightstep.podspec.src
+++ b/lightstep.podspec.src
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = { "LightStep" => "support@lightstep.com" }
   s.source           = { :git => "https://github.com/lightstep/lightstep-tracer-objc.git", :tag => s.version.to_s }
 
-  s.platforms        = { :ios => '7.0', :osx => '10.11', :tvos => '9.0' }
+  s.platforms        = { :ios => '8.0', :osx => '10.11', :tvos => '9.0' }
 
   s.source_files = 'Pod/Classes/*'
   s.requires_arc = true


### PR DESCRIPTION
This PR adds support for MacOS to the tracer.

- Refactors platform ID logic out via conditional targets.
- Removes background task logic from flush on MacOS as it is not required.